### PR TITLE
feat(aws-architecture-diagram): add Agent Skills frontmatter

### DIFF
--- a/skills/aws-architecture-diagram/SKILL.md
+++ b/skills/aws-architecture-diagram/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: aws-architecture-diagram
-description: Generate Draw.io XML architecture diagrams with accurate AWS service icons. Use when the user asks to create, update, or generate an AWS architecture diagram, mentions Draw.io diagrams, wants to visualize AWS infrastructure, needs architecture documentation, or says things like "diagram this architecture", "create an AWS diagram", "visualize this setup", or "document this infrastructure". Also use when discussing system design, cloud architecture, or infrastructure planning that would benefit from a visual diagram.
+description: Generate Draw.io XML architecture diagrams with accurate AWS service icons. Use when the user asks to create, update, or visualize an AWS architecture diagram, or mentions Draw.io diagrams for AWS infrastructure.
+user-invocable: true
+argument-hint: "describe the AWS architecture to diagram"
 ---
 
 # AWS Architecture Diagram Skill

--- a/skills/aws-architecture-diagram/SKILL.md
+++ b/skills/aws-architecture-diagram/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: aws-architecture-diagram
+description: Generate Draw.io XML architecture diagrams with accurate AWS service icons. Use when the user asks to create, update, or generate an AWS architecture diagram, mentions Draw.io diagrams, wants to visualize AWS infrastructure, needs architecture documentation, or says things like "diagram this architecture", "create an AWS diagram", "visualize this setup", or "document this infrastructure". Also use when discussing system design, cloud architecture, or infrastructure planning that would benefit from a visual diagram.
+---
+
 # AWS Architecture Diagram Skill
 
 Generate Draw.io XML architecture diagrams with accurate AWS service icons.


### PR DESCRIPTION
Thank you for creating this useful skill! This PR adds Agent Skills standard frontmatter with an optimized description for better skill triggering.

Without explicit frontmatter, the first paragraph becomes the description by default, but a well-crafted description with specific trigger phrases and contexts significantly improves Claude's ability to invoke the skill at the right time.

## References

- [Claude Code Skills Documentation](https://code.claude.com/docs/en/skills#frontmatter-reference)
- [Agent Skills Best Practices](https://docs.anthropic.com/en/agents-and-tools/agent-skills/best-practices#writing-effective-descriptions)